### PR TITLE
be more liberal in what we accept as a character

### DIFF
--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -22,6 +22,41 @@ Vector[coll] { "[" expression* "]" }
 Map[coll] { "{" expression* "}" }
 VarName { Symbol }
 
+coll[@isGroup=Coll] {
+  List | Vector | Map
+}
+prefixColl[@isGroup=PrefixColl] {
+  Set |
+  AnonymousFunction |
+  NamespacedMap |
+  Constructor |
+  ReaderConditional |
+  ReaderMetadata |
+  Metadata |
+  Deref |
+  Quote |
+  SyntaxQuote |
+  Unquote |
+  UnquoteSplice
+}
+
+prefixEdge[@isGroup=PrefixEdge] {
+ KeywordPrefix |
+ ConstructorPrefix |
+ "#" |
+ "##" |
+ "#'" |
+ "#?" |
+ "#^" |
+ "#_" |
+ "'" |
+ "`" |
+ "~" |
+ "~@" |
+ "^" |
+ "@"
+}
+
 @skip {} {
   dataLiteral { "#" ident }
   DataLiteral { dataLiteral }
@@ -109,7 +144,10 @@ Operator { !operator Symbol }
     (!["] | "\\" _)+
   }
 
-  Character { "\\" (std.asciiLetter | std.digit | "@")+ }
+  multiChar { ("u" std.digit+) | ("o" std.digit+) | (std.asciiLetter std.asciiLetter+) }
+  singleChar { ![\n\r\s] }
+  @precedence { multiChar, singleChar }
+  Character { "\\" (multiChar | singleChar) }
 
 }
 

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -22,41 +22,6 @@ Vector[coll] { "[" expression* "]" }
 Map[coll] { "{" expression* "}" }
 VarName { Symbol }
 
-coll[@isGroup=Coll] {
-  List | Vector | Map
-}
-prefixColl[@isGroup=PrefixColl] {
-  Set |
-  AnonymousFunction |
-  NamespacedMap |
-  Constructor |
-  ReaderConditional |
-  ReaderMetadata |
-  Metadata |
-  Deref |
-  Quote |
-  SyntaxQuote |
-  Unquote |
-  UnquoteSplice
-}
-
-prefixEdge[@isGroup=PrefixEdge] {
- KeywordPrefix |
- ConstructorPrefix |
- "#" |
- "##" |
- "#'" |
- "#?" |
- "#^" |
- "#_" |
- "'" |
- "`" |
- "~" |
- "~@" |
- "^" |
- "@"
-}
-
 @skip {} {
   dataLiteral { "#" ident }
   DataLiteral { dataLiteral }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -114,10 +114,27 @@ nil
 ==>
 Program(Nil)
 
-# Characters
-\f \u0194 \o123 \newline \A \@
+# other chars
+\@ \; \[ \) \# \$ \' \\ \"
 ==>
-Program(Character,Character,Character,Character,Character,Character)
+Program(Character,Character,Character,Character,Character,Character,Character,Character,Character)
+
+# unicode
+\u0194
+==>
+Program(Character)
+
+# octal
+\o123
+==>
+Program(Character)
+
+# special-case chars
+\newline \space \backspace
+	\tab
+\formfeed \return \someOtherToken
+==>
+Program(Character,Character,Character,Character,Character,Character,Character)
 
 # Line comments
 ;; comment


### PR DESCRIPTION
Original problem was that `\;` was not interpreting the `;` as a char, because we had a too-restrictive definition for character.

