### PR TITLE
Upgrade to lezer v0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lezer-clojure",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "lezer-based Clojure(Script) grammar",
   "main": "dist/index.cjs",
   "author": "Martin Kavalar <martin@nextjournal.com>",
@@ -14,12 +14,12 @@
   "types": "dist/index.d.ts",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "lezer-generator": "^0.12.0",
+    "lezer-generator": "^0.13.0",
     "mocha": "^8.1.3",
     "rollup": "^2.27.1"
   },
   "dependencies": {
-    "lezer": "^0.12.0"
+    "lezer": "^0.13.0"
   },
   "scripts": {
     "build": "lezer-generator src/clojure.grammar -o src/parser && rollup -c",

--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -111,7 +111,6 @@ Operator { !operator Symbol }
 
   multiChar { ("u" std.digit+) | ("o" std.digit+) | (std.asciiLetter std.asciiLetter+) }
   singleChar { ![\n\r\s] }
-  @precedence { multiChar, singleChar }
   Character { "\\" (multiChar | singleChar) }
 
 }


### PR DESCRIPTION
Is it possible you have a pending push on this repo @mhuebert? I noticed nextjournal already depends on `0.1.9` while the package.json is still at `0.1.8`. That's why I picked `0.1.10` as the version here.