### PR TITLE
Fix rules for chars

### DIFF
--- a/src/clojure.grammar
+++ b/src/clojure.grammar
@@ -109,9 +109,11 @@ Operator { !operator Symbol }
     (!["] | "\\" _)+
   }
 
-  multiChar { ("u" std.digit+) | ("o" std.digit+) | (std.asciiLetter std.asciiLetter+) }
-  singleChar { ![\n\r\s] }
-  Character { "\\" (multiChar | singleChar) }
+  unicodeChar { "u" $[0-9a-fA-F] $[0-9a-fA-F] $[0-9a-fA-F] $[0-9a-fA-F]}
+  octalChar { "o" $[0-3]? $[0-7] $[0-7]? }
+  specialChar { "newline" | "space" | "tab" | "formfeed" | "backspace" | "return" }
+  singleChar { ![\n] }
+  Character { "\\" ( octalChar | unicodeChar |  singleChar | specialChar ) }
 
 }
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -114,27 +114,30 @@ nil
 ==>
 Program(Nil)
 
+# simple chars
+\a \b \n \r \s
+==>
+Program(Character,Character,Character,Character,Character)
+
 # other chars
 \@ \; \[ \) \# \$ \' \\ \"
 ==>
 Program(Character,Character,Character,Character,Character,Character,Character,Character,Character)
 
 # unicode
-\u0194
+\u0194 \uFFFF
 ==>
-Program(Character)
+Program(Character,Character)
 
 # octal
-\o123
+\o123 \o372 \o0
 ==>
-Program(Character)
+Program(Character, Character, Character)
 
 # special-case chars
-\newline \space \backspace
-	\tab
-\formfeed \return \someOtherToken
+\newline \space \backspace \tab \formfeed \return
 ==>
-Program(Character,Character,Character,Character,Character,Character,Character)
+Program(Character,Character,Character,Character,Character,Character)
 
 # Line comments
 ;; comment


### PR DESCRIPTION
This PR addresses several issues regarding char detection. 

Issues: 
- Unicode chars with hexadecimal digits are _not_ allowed.
- Unicode and octal chars with 1 or more digits are allowed. 
    - Clojure accepts exactly four hex digits for Unicode
    - Octals must be between 0 and 377
- Octal chars with the digits 8 & 9 were allowed
- arbitrary special chars (e.g. `\newline`) are allowed
    - Clojure provides a fixed set for special chars

`![\n\r\s]` is not correct and results in:
https://github.com/nextjournal/clojure-mode/issues/9

Actually, Clojure accepts `\n` and white spaces when in a form… Which is crazy…
```clojure-repl
Clojure 1.10.3
user=> \
Syntax error reading source at (REPL:2:1).
EOF while reading character
user=> [\ \a]
[\space \a]
user=> [\
 \a]
[\newline \a]
user=>
```

resolves https://github.com/nextjournal/clojure-mode/issues/22, resolves https://github.com/nextjournal/clojure-mode/issues/9